### PR TITLE
Avoid deinit of ENET PLL when booting as secondary core

### DIFF
--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -258,11 +258,13 @@ static ALWAYS_INLINE void clock_init(void)
 #ifdef CONFIG_INIT_ENET_PLL
 	CLOCK_InitSysPll1(&sysPll1Config);
 #else
+#ifndef DUAL_CORE_MU_ENABLED
 	/* Bypass Sys Pll1. */
 	CLOCK_SetPllBypass(kCLOCK_PllSys1, true);
 
 	/* DeInit Sys Pll1. */
 	CLOCK_DeinitSysPll1();
+#endif
 #endif
 
 	/* Init Sys Pll2. */


### PR DESCRIPTION
When `CONFIG_INIT_ENET_PLL` is undefined and `DUAL_CORE_MU_ENABLED` is defined, do not deinit `SysPll1` as it might could be controlled by primary core